### PR TITLE
 surefire plugin: do not ignore failed tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,9 @@
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Money and Currency - JavaMoney parent</name>
-    <description>JavaMoney Parent POM</description>
+    <description>The root "POM" project for all modules under org.javamoney.
+        This includes the RI/TCK projects, but not jsr354-api (which is standalone).
+    </description>
     <url>http://javamoney.org</url>
     <inceptionYear>2012</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,6 @@
                         <useSystemClassLoader>true</useSystemClassLoader>
                         <skipTests>false</skipTests>
                         <trimStackTrace>false</trimStackTrace>
-                        <testFailureIgnore>true</testFailureIgnore>
                         <forkMode>once</forkMode>
                         <includes>
                             <include>**/*Test.java</include>


### PR DESCRIPTION
While I investigated why jsr354-ri was built successfully in TravisCI even when there was test failings it turned out that  jsr354-ri module inherits from from the javamoney-parent v1.0 and here the surefire plugin is configured to ignore test failings.
Not sure why this was configured but we definitely should remove the option because it makes CI useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/javamoney-parent/5)
<!-- Reviewable:end -->
